### PR TITLE
Correct the address for the cadvisor image

### DIFF
--- a/kubernetes-agent/checkmk_agent.yaml
+++ b/kubernetes-agent/checkmk_agent.yaml
@@ -284,7 +284,7 @@ spec:
           requests:
             cpu: 150m
             memory: 200Mi
-      - image: k8s.gcr.io/cadvisor:v0.40.0
+      - image: gcr.io/cadvisor/cadvisor:v0.40.0
         name: cadvisor
         args:
         - --disable_metrics=tcp,udp,percpu,sched


### PR DESCRIPTION
There is no pulling possible for me with the address given in the yaml. Switching to the address provided by the release fixes this problem.

Address has been obtained from https://github.com/google/cadvisor/releases/tag/v0.40.0